### PR TITLE
Add watch mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Plug 'yaegassy/coc-vitest', {'do': 'yarn install --frozen-lockfile'}
 - `vitest.terminal.enableSplitRight`: Use vertical belowright for vitest terminal window, default: `false`
 - `vitest.codelens.enable`: Enable codelens, default: `true`
 - `vitest.codelens.title`: CodeLens title. Can be changed to any display, default: `">> [Run Vitest]"`
+- `vitest.watch`: Run tests in watch mode, default: `false`
 
 ## Commands
 

--- a/package.json
+++ b/package.json
@@ -79,6 +79,11 @@
           "type": "string",
           "default": ">> [Run Vitest]",
           "description": "CodeLens title. Can be changed to any display."
+        },
+        "vitest.watch": {
+          "type": "boolean",
+          "default": false,
+          "description": "Run tests in watch mode"
         }
       }
     },

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,7 +1,7 @@
 import { Terminal, Uri, window, workspace } from 'coc.nvim';
 import fs from 'fs';
 import path from 'path';
-import { getConfigVitestTerminalEnableSplitRight } from './config';
+import { getConfigVitestTerminalEnableSplitRight, getConfigVitestWatchMode } from './config';
 import { findCurrentTestName, isSupportLang } from './utils';
 
 const NOT_TEST_FILE_MESSAGE = 'This file is not a test file!';
@@ -36,7 +36,9 @@ async function runVitest(filePath?: string, testName?: string) {
     terminal = await window.createTerminal({ name: 'vitest', cwd: workspace.root });
 
     const args: string[] = [];
-    args.push('run');
+    if (!getConfigVitestWatchMode()) {
+      args.push('run');
+    }
 
     if (testName && filePath) {
       args.push('--testNamePattern');

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,5 +13,9 @@ export function getConfigVitestCodeLensEnable() {
 }
 
 export function getConfigVitestCodeLensTitle() {
-  return workspace.getConfiguration('vitest').get('codelens.title', '>> [RUN Vitest]');
+  return workspace.getConfiguration('vitest').get<string>('codelens.title', '>> [RUN Vitest]');
+}
+
+export function getConfigVitestWatchMode() {
+  return workspace.getConfiguration('vitest').get<boolean>('watch', false);
 }


### PR DESCRIPTION
Fixes #1 

Yes, you can open another terminal, but commands such as `VitestCurrent` and `te` are not easily replicated with a new terminal.